### PR TITLE
refer to the buildpack as `MRI` instead of `Ruby` or `Ruby MRI`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ the `$GEM_PATH` environment variable.
 
 ## Integration
 
-The MRI CNB provides `mri` as a dependency. Downstream buildpacks,
+The MRI CNB provides `ruby` as a dependency. Downstream buildpacks,
 can require the ruby dependency by generating
 [Build Plan TOML](https://github.com/buildpacks/spec/blob/master/buildpack.md#build-plan-toml)
 file that looks like the following:

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.2"
 
 [buildpack]
   id = "org.cloudfoundry.ruby-mri"
-  name = "Ruby MRI Buildpack"
+  name = "MRI Buildpack"
   version = "{{ .Version }}"
 
 [metadata]
@@ -13,7 +13,7 @@ api = "0.2"
 
   [[metadata.dependencies]]
     id = "ruby"
-    name = "Ruby MRI"
+    name = "MRI"
     sha256 = "01b7d7a8a3031f15079e0ca1245e002575f47c8943f68508d86ba4f46ac24190"
     source = "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.7.tar.gz"
     source_sha256 = "0b2d0d5e3451b6ab454f81b1bfca007407c0548dea403f1eba2e429da4add6d4"
@@ -23,7 +23,7 @@ api = "0.2"
 
   [[metadata.dependencies]]
     id = "ruby"
-    name = "Ruby MRI"
+    name = "MRI"
     sha256 = "738900eab9e0cb8139415556d4022d6d9c4947ed7c46f78862785028f45fa239"
     source = "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.8.tar.gz"
     source_sha256 = "6c0bdf07876c69811a9e7dc237c43d40b1cb6369f68e0e17953d7279b524ad9a"
@@ -33,7 +33,7 @@ api = "0.2"
 
   [[metadata.dependencies]]
     id = "ruby"
-    name = "Ruby MRI"
+    name = "MRI"
     sha256 = "a23c26ec93e34ca05328390107ff40034b5103afb91194ebf70f66f0c0866db4"
     source = "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.gz"
     source_sha256 = "66976b716ecc1fd34f9b7c3c2b07bbd37631815377a2e3e85a5b194cfdcbed7d"
@@ -43,7 +43,7 @@ api = "0.2"
 
   [[metadata.dependencies]]
     id = "ruby"
-    name = "Ruby MRI"
+    name = "MRI"
     sha256 = "9f860a6520bf8774fcb06ea9a33ae17818875b747b58ca11b0690223c7126493"
     source = "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.gz"
     source_sha256 = "364b143def360bac1b74eb56ed60b1a0dca6439b00157ae11ff77d5cd2e92291"
@@ -53,7 +53,7 @@ api = "0.2"
 
   [[metadata.dependencies]]
     id = "ruby"
-    name = "Ruby MRI"
+    name = "MRI"
     sha256 = "68cd2baeb33c1f10a873aab8e492d4547f3b13d1a6302930ac25bcedf45d51ce"
     source = "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.gz"
     source_sha256 = "8c99aa93b5e2f1bc8437d1bbbefd27b13e7694025331f77245d0c068ef1f8cbe"
@@ -64,7 +64,7 @@ api = "0.2"
   [[metadata.dependencies]]
     deprecation_date = "2023-04-01T00:00:00Z"
     id = "ruby"
-    name = "Ruby MRI"
+    name = "MRI"
     sha256 = "e25620088c536685f81aaae0f7f03c2143aa3dc9078a99707168915e85568f04"
     source = "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.gz"
     source_sha256 = "d418483bdd0000576c1370571121a6eb24582116db0b7bb2005e90e250eae418"

--- a/integration/logging_test.go
+++ b/integration/logging_test.go
@@ -53,15 +53,15 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).ToNot(HaveOccurred())
 
 			sequence := []interface{}{
-				fmt.Sprintf("Ruby MRI Buildpack %s", buildpackVersion),
-				"  Resolving Ruby MRI version",
+				fmt.Sprintf("MRI Buildpack %s", buildpackVersion),
+				"  Resolving MRI version",
 				"    Candidate version sources (in priority order):",
 				"      buildpack.yml -> \"2.7.x\"",
 				"",
-				MatchRegexp(`    Selected Ruby MRI version \(using buildpack\.yml\): 2\.7\.\d+`),
+				MatchRegexp(`    Selected MRI version \(using buildpack\.yml\): 2\.7\.\d+`),
 				"",
 				"  Executing build process",
-				MatchRegexp(`    Installing Ruby MRI 2\.7\.\d+`),
+				MatchRegexp(`    Installing MRI 2\.7\.\d+`),
 				MatchRegexp(`      Completed in \d+\.\d+`),
 				"",
 				"  Configuring environment",

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -79,15 +79,15 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(GetBuildLogs(logs.String())).To(ContainSequence([]interface{}{
-				fmt.Sprintf("Ruby MRI Buildpack %s", buildpackVersion),
-				"  Resolving Ruby MRI version",
+				fmt.Sprintf("MRI Buildpack %s", buildpackVersion),
+				"  Resolving MRI version",
 				"    Candidate version sources (in priority order):",
 				"      buildpack.yml -> \"2.7.x\"",
 				"",
-				MatchRegexp(`    Selected Ruby MRI version \(using buildpack\.yml\): 2\.7\.\d+`),
+				MatchRegexp(`    Selected MRI version \(using buildpack\.yml\): 2\.7\.\d+`),
 				"",
 				"  Executing build process",
-				MatchRegexp(`    Installing Ruby MRI 2\.\d+\.\d+`),
+				MatchRegexp(`    Installing MRI 2\.\d+\.\d+`),
 				MatchRegexp(`      Completed in \d+\.\d+`),
 				"",
 				"  Configuring environment",
@@ -115,12 +115,12 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(secondImage.Buildpacks[0].Layers).To(HaveKey("ruby"))
 
 			Expect(GetBuildLogs(logs.String())).To(ContainSequence([]interface{}{
-				fmt.Sprintf("Ruby MRI Buildpack %s", buildpackVersion),
-				"  Resolving Ruby MRI version",
+				fmt.Sprintf("MRI Buildpack %s", buildpackVersion),
+				"  Resolving MRI version",
 				"    Candidate version sources (in priority order):",
 				"      buildpack.yml -> \"2.7.x\"",
 				"",
-				MatchRegexp(`    Selected Ruby MRI version \(using buildpack\.yml\): 2\.7\.\d+`),
+				MatchRegexp(`    Selected MRI version \(using buildpack\.yml\): 2\.7\.\d+`),
 				"",
 				"  Reusing cached layer /layers/org.cloudfoundry.ruby-mri/ruby",
 			}), logs.String())
@@ -172,15 +172,15 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(GetBuildLogs(logs.String())).To(ContainSequence([]interface{}{
-				fmt.Sprintf("Ruby MRI Buildpack %s", buildpackVersion),
-				"  Resolving Ruby MRI version",
+				fmt.Sprintf("MRI Buildpack %s", buildpackVersion),
+				"  Resolving MRI version",
 				"    Candidate version sources (in priority order):",
 				"      buildpack.yml -> \"2.7.x\"",
 				"",
-				MatchRegexp(`    Selected Ruby MRI version \(using buildpack\.yml\): 2\.7\.\d+`),
+				MatchRegexp(`    Selected MRI version \(using buildpack\.yml\): 2\.7\.\d+`),
 				"",
 				"  Executing build process",
-				MatchRegexp(`    Installing Ruby MRI 2\.7\.\d+`),
+				MatchRegexp(`    Installing MRI 2\.7\.\d+`),
 				MatchRegexp(`      Completed in \d+\.\d+`),
 				"",
 				"  Configuring environment",
@@ -208,15 +208,15 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(secondImage.Buildpacks[0].Layers).To(HaveKey("ruby"))
 
 			Expect(GetBuildLogs(logs.String())).To(ContainSequence([]interface{}{
-				fmt.Sprintf("Ruby MRI Buildpack %s", buildpackVersion),
-				"  Resolving Ruby MRI version",
+				fmt.Sprintf("MRI Buildpack %s", buildpackVersion),
+				"  Resolving MRI version",
 				"    Candidate version sources (in priority order):",
 				"      buildpack.yml -> \"2.6.x\"",
 				"",
-				MatchRegexp(`    Selected Ruby MRI version \(using buildpack\.yml\): 2\.6\.\d+`),
+				MatchRegexp(`    Selected MRI version \(using buildpack\.yml\): 2\.6\.\d+`),
 				"",
 				"  Executing build process",
-				MatchRegexp(`    Installing Ruby MRI 2\.6\.\d+`),
+				MatchRegexp(`    Installing MRI 2\.6\.\d+`),
 				MatchRegexp(`      Completed in \d+\.\d+`),
 				"",
 				"  Configuring environment",

--- a/ruby/build.go
+++ b/ruby/build.go
@@ -37,7 +37,7 @@ type Executable interface {
 func Build(entries EntryResolver, dependencies DependencyManager, planRefinery BuildPlanRefinery, logger LogEmitter, clock Clock, gem Executable) packit.BuildFunc {
 	return func(context packit.BuildContext) (packit.BuildResult, error) {
 		logger.Title("%s %s", context.BuildpackInfo.Name, context.BuildpackInfo.Version)
-		logger.Process("Resolving Ruby MRI version")
+		logger.Process("Resolving MRI version")
 
 		entry := entries.Resolve(context.Plan.Entries)
 
@@ -89,7 +89,7 @@ func Build(entries EntryResolver, dependencies DependencyManager, planRefinery B
 			"built_at": clock.Now().Format(time.RFC3339Nano),
 		}
 
-		logger.Subprocess("Installing Ruby MRI %s", dependency.Version)
+		logger.Subprocess("Installing MRI %s", dependency.Version)
 		then := clock.Now()
 		err = dependencies.Install(dependency, context.CNBPath, rubyLayer.Path)
 		if err != nil {

--- a/ruby/build_test.go
+++ b/ruby/build_test.go
@@ -75,7 +75,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		}
 
 		dependencyManager = &fakes.DependencyManager{}
-		dependencyManager.ResolveCall.Returns.Dependency = postal.Dependency{Name: "Ruby MRI"}
+		dependencyManager.ResolveCall.Returns.Dependency = postal.Dependency{Name: "MRI"}
 
 		planRefinery = &fakes.BuildPlanRefinery{}
 
@@ -188,17 +188,17 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(dependencyManager.ResolveCall.Receives.Stack).To(Equal("some-stack"))
 
 		Expect(planRefinery.BillOfMaterialCall.CallCount).To(Equal(1))
-		Expect(planRefinery.BillOfMaterialCall.Receives.Dependency).To(Equal(postal.Dependency{Name: "Ruby MRI"}))
+		Expect(planRefinery.BillOfMaterialCall.Receives.Dependency).To(Equal(postal.Dependency{Name: "MRI"}))
 
-		Expect(dependencyManager.InstallCall.Receives.Dependency).To(Equal(postal.Dependency{Name: "Ruby MRI"}))
+		Expect(dependencyManager.InstallCall.Receives.Dependency).To(Equal(postal.Dependency{Name: "MRI"}))
 		Expect(dependencyManager.InstallCall.Receives.CnbPath).To(Equal(cnbDir))
 		Expect(dependencyManager.InstallCall.Receives.LayerPath).To(Equal(filepath.Join(layersDir, "ruby")))
 
 		Expect(gem.ExecuteCall.Receives.Execution.Args).To(Equal([]string{"env", "path"}))
 
 		Expect(buffer.String()).To(ContainSubstring("Some Buildpack some-version"))
-		Expect(buffer.String()).To(ContainSubstring("Resolving Ruby MRI version"))
-		Expect(buffer.String()).To(ContainSubstring("Selected Ruby MRI version (using buildpack.yml): "))
+		Expect(buffer.String()).To(ContainSubstring("Resolving MRI version"))
+		Expect(buffer.String()).To(ContainSubstring("Selected MRI version (using buildpack.yml): "))
 		Expect(buffer.String()).To(ContainSubstring("Executing build process"))
 		Expect(buffer.String()).To(ContainSubstring("Configuring environment"))
 	})
@@ -374,7 +374,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			dependencyManager.ResolveCall.Returns.Dependency = postal.Dependency{
-				Name:   "Ruby MRI",
+				Name:   "MRI",
 				SHA256: "some-sha",
 			}
 		})
@@ -405,15 +405,15 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(planRefinery.BillOfMaterialCall.CallCount).To(Equal(1))
 			Expect(planRefinery.BillOfMaterialCall.Receives.Dependency).To(Equal(postal.Dependency{
-				Name:   "Ruby MRI",
+				Name:   "MRI",
 				SHA256: "some-sha",
 			}))
 
 			Expect(dependencyManager.InstallCall.CallCount).To(Equal(0))
 
 			Expect(buffer.String()).To(ContainSubstring("Some Buildpack some-version"))
-			Expect(buffer.String()).To(ContainSubstring("Resolving Ruby MRI version"))
-			Expect(buffer.String()).To(ContainSubstring("Selected Ruby MRI version (using buildpack.yml): "))
+			Expect(buffer.String()).To(ContainSubstring("Resolving MRI version"))
+			Expect(buffer.String()).To(ContainSubstring("Selected MRI version (using buildpack.yml): "))
 			Expect(buffer.String()).To(ContainSubstring("Reusing cached layer"))
 			Expect(buffer.String()).ToNot(ContainSubstring("Executing build process"))
 		})

--- a/ruby/log_emitter_test.go
+++ b/ruby/log_emitter_test.go
@@ -32,23 +32,23 @@ func testLogEmitter(t *testing.T, context spec.G, it spec.S) {
 				Metadata: map[string]interface{}{"version-source": "some-source"},
 			}
 			dependency := postal.Dependency{
-				Name:    "Ruby MRI",
+				Name:    "MRI",
 				Version: "some-version",
 			}
 
 			emitter.SelectedDependency(entry, dependency, time.Now())
-			Expect(buffer.String()).To(Equal("    Selected Ruby MRI version (using some-source): some-version\n\n"))
+			Expect(buffer.String()).To(Equal("    Selected MRI version (using some-source): some-version\n\n"))
 		})
 
 		context("when the version source is missing", func() {
 			it("prints details about the selected dependency", func() {
 				dependency := postal.Dependency{
-					Name:    "Ruby MRI",
+					Name:    "MRI",
 					Version: "some-version",
 				}
 
 				emitter.SelectedDependency(packit.BuildpackPlanEntry{}, dependency, time.Now())
-				Expect(buffer.String()).To(Equal("    Selected Ruby MRI version (using <unknown>): some-version\n\n"))
+				Expect(buffer.String()).To(Equal("    Selected MRI version (using <unknown>): some-version\n\n"))
 			})
 		})
 
@@ -63,14 +63,14 @@ func testLogEmitter(t *testing.T, context spec.G, it spec.S) {
 				}
 				dependency := postal.Dependency{
 					DeprecationDate: deprecationDate,
-					Name:            "Ruby MRI",
+					Name:            "MRI",
 					Version:         "some-version",
 				}
 
 				emitter.SelectedDependency(entry, dependency, now)
-				Expect(buffer.String()).To(ContainSubstring("    Selected Ruby MRI version (using some-source): some-version\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Version some-version of Ruby MRI will be deprecated after 2021-04-01.\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Migrate your application to a supported version of Ruby MRI before this time.\n\n"))
+				Expect(buffer.String()).To(ContainSubstring("    Selected MRI version (using some-source): some-version\n"))
+				Expect(buffer.String()).To(ContainSubstring("      Version some-version of MRI will be deprecated after 2021-04-01.\n"))
+				Expect(buffer.String()).To(ContainSubstring("      Migrate your application to a supported version of MRI before this time.\n\n"))
 			})
 		})
 
@@ -85,14 +85,14 @@ func testLogEmitter(t *testing.T, context spec.G, it spec.S) {
 				}
 				dependency := postal.Dependency{
 					DeprecationDate: deprecationDate,
-					Name:            "Ruby MRI",
+					Name:            "MRI",
 					Version:         "some-version",
 				}
 
 				emitter.SelectedDependency(entry, dependency, now)
-				Expect(buffer.String()).To(ContainSubstring("    Selected Ruby MRI version (using some-source): some-version\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Version some-version of Ruby MRI is deprecated.\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Migrate your application to a supported version of Ruby MRI.\n\n"))
+				Expect(buffer.String()).To(ContainSubstring("    Selected MRI version (using some-source): some-version\n"))
+				Expect(buffer.String()).To(ContainSubstring("      Version some-version of MRI is deprecated.\n"))
+				Expect(buffer.String()).To(ContainSubstring("      Migrate your application to a supported version of MRI.\n\n"))
 			})
 		})
 
@@ -107,14 +107,14 @@ func testLogEmitter(t *testing.T, context spec.G, it spec.S) {
 				}
 				dependency := postal.Dependency{
 					DeprecationDate: deprecationDate,
-					Name:            "Ruby MRI",
+					Name:            "MRI",
 					Version:         "some-version",
 				}
 
 				emitter.SelectedDependency(entry, dependency, now)
-				Expect(buffer.String()).To(ContainSubstring("    Selected Ruby MRI version (using some-source): some-version\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Version some-version of Ruby MRI is deprecated.\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Migrate your application to a supported version of Ruby MRI.\n\n"))
+				Expect(buffer.String()).To(ContainSubstring("    Selected MRI version (using some-source): some-version\n"))
+				Expect(buffer.String()).To(ContainSubstring("      Version some-version of MRI is deprecated.\n"))
+				Expect(buffer.String()).To(ContainSubstring("      Migrate your application to a supported version of MRI.\n\n"))
 			})
 		})
 	})


### PR DESCRIPTION
I left the actual `name` of the buildpack  as `ruby` as to not break the api